### PR TITLE
Dockerfile patch for using opencv-python module

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -14,10 +14,6 @@ RUN pip install --upgrade pip && \
 
 FROM python:3.9-slim
 
-RUN apt update && \
-    apt install -y curl libglib2.0-0 libgl1-mesa-glx && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -14,6 +14,10 @@ RUN pip install --upgrade pip && \
 
 FROM python:3.9-slim
 
+RUN apt update && \
+    apt install -y curl libglib2.0-0 libgl1-mesa-glx && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,6 +4,7 @@ fastapi==0.88.0
 h11==0.14.0
 idna==3.4
 numpy==1.24.0
+opencv-python==4.6.0.66
 Pillow==9.3.0
 pydantic==1.10.2
 python-multipart==0.0.5

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,7 +4,7 @@ fastapi==0.88.0
 h11==0.14.0
 idna==3.4
 numpy==1.24.0
-opencv-python==4.6.0.66
+opencv-python-headless==4.6.0.66
 Pillow==9.3.0
 pydantic==1.10.2
 python-multipart==0.0.5


### PR DESCRIPTION
# Dockerfile patch for using opencv-python
This uses a python package called opencv-python-headless to install and use opencv-python in the api container.