### PR TITLE
Add API logging

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,6 @@
+from enum import Enum
 import json
+import logging
 from typing import List
 from fastapi import FastAPI, File, Request, UploadFile, BackgroundTasks
 from fastapi.responses import JSONResponse
@@ -9,6 +11,23 @@ from networking import image_to_model
 
 app = FastAPI()
 templates = Jinja2Templates(directory="./templates")
+
+class LoggingLevel(Enum):
+    NOTSET = logging.NOTSET
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL
+
+    @classmethod
+    def get_level(cls, level: str):
+        return cls.__members__.get(level, cls.NOTSET).value
+
+LOGGER_NAME = "main"
+FORMAT = "| %(asctime)s | %(levelname)s | %(name)s | %(message)s |"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 @app.get('/classify')

--- a/api/networking.py
+++ b/api/networking.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from aescipher import AESCipher
 
 
@@ -6,6 +7,9 @@ AES = AESCipher()
 HOST_FIREML = "fireml"
 PORT_FIREML = 5000
 CHUNK_SIZE = 1024
+
+LOGGER_NAME = "networking"
+LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 async def image_to_model(client_id: bytes, image) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       VAULT_ADDR: "http://vault:8200"
       VAULT_TOKEN: "${TOKEN}"
+      LOG_LEVEL: "${LOG_LEVEL}"
     volumes:
       - ./.env:/home/wildfire/api/.vault-token
 


### PR DESCRIPTION
Working in progress as I have to fix feature branch to make it work to see the logging.
    Improvement suggestions:
    1. Remove duplicated code for logging setup that exists in both API and FireML - create utilities/logging.py ? It will look nicer to  reuse code from there instead of having in both places. 
    2 Add actual api logging - cannot do it now until frontend-fixes are merges because it contains some code refactoring which will cause conflicts if log statements are added in the logging-api branch.

Do I have to create pull request for this to be able to merge to deployment? Do it anyway so you see.